### PR TITLE
Update README.md (instructions for OS X)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,14 @@ If you are unable to sign in to your Google account, turn on access for less sec
 Install
 -------
 
-OSX:
+OS X:
 
 ```bash
 # Install libspotify
 $ brew install homebrew/binary/libspotify
+$ brew install libffi
 # Workaround on OSX (see https://pyspotify.mopidy.com/en/latest/installation/)
-$ sudo ln -s /usr/local/opt/libspotify/lib/libspotify.12.1.51.dylib \
+$ ln -s /usr/local/opt/libspotify/lib/libspotify.12.1.51.dylib \
 /usr/local/opt/libspotify/lib/libspotify
 # Install pyportify
 $ pip install pyportify


### PR DESCRIPTION
Adds a `brew install libffi` command since it's required to compile pyspotify.
Removes `sudo` on creating a libspotify symlink in OS X - there's no point since /usr/local/ is user-accessible.

I'm going to create a pull request for the `pyspotify` library too.