### PR TITLE
Add itsdangerous to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pyspotify>=2.0.0b4
 six>=1.6.1
 gevent>=1.0.1
 geventhttpclient>=1.1.0
+itsdangerous>=0.24


### PR DESCRIPTION
Apparently I didn't have this installed and things crashed (OS X 10.10.3 w/ Python 2.7.9).

I updated the requirements, built everything in a clean virtualenv and it works perfectly.