### PR TITLE
fix geventhttpclient crash

### DIFF
--- a/pyportify/google.py
+++ b/pyportify/google.py
@@ -24,13 +24,11 @@ class Mobileclient(object):
         self._auth = None
         self._sj_client = HTTPClient.from_url(
             "https://{0}{1}".format(SJ_DOMAIN, SJ_URL),
-            headers_type=dict,
             concurrency=20,
             network_timeout=15,
             )
         self._pl_client = HTTPClient.from_url(
             "https://{0}{1}".format(SJ_DOMAIN, SJ_URL),
-            headers_type=dict,
             concurrency=1,
             network_timeout=120,
             )
@@ -87,7 +85,7 @@ class Mobileclient(object):
             "Authorization": "GoogleLogin auth={0}".format(self._auth),
             "Content-type": "application/json",
         }
-        res = self._sj_client.get(SJ_URL + url, headers)
+        res = self._sj_client.request('GET', SJ_URL + url, headers=headers)
         body = res.read()
         data = json.loads(body)
         return data
@@ -98,7 +96,7 @@ class Mobileclient(object):
             "Authorization": "GoogleLogin auth={0}".format(self._auth),
             "Content-type": "application/json",
         }
-        res = self._pl_client.post(SJ_URL + url, data, headers)
+        res = self._pl_client.post('POST', SJ_URL + url, body=data, headers=headers)
         body = res.read()
         data = json.loads(body)
         return data

--- a/pyportify/google.py
+++ b/pyportify/google.py
@@ -85,7 +85,10 @@ class Mobileclient(object):
             "Authorization": "GoogleLogin auth={0}".format(self._auth),
             "Content-type": "application/json",
         }
-        res = self._sj_client.request('GET', SJ_URL + url, headers=headers)
+        res = self._sj_client.request('GET',
+            SJ_URL + url,
+            headers=headers
+        )
         body = res.read()
         data = json.loads(body)
         return data
@@ -96,7 +99,11 @@ class Mobileclient(object):
             "Authorization": "GoogleLogin auth={0}".format(self._auth),
             "Content-type": "application/json",
         }
-        res = self._pl_client.post('POST', SJ_URL + url, body=data, headers=headers)
+        res = self._pl_client.post('POST',
+            SJ_URL + url,
+            body=data,
+            headers=headers
+        )
         body = res.read()
         data = json.loads(body)
         return data


### PR DESCRIPTION
I don't know if this is due to an API change in that library (I'm not a python dev at all) but I had to make this change to avoid `'dict' object has no attribute 'add'` crashes. Should fix #38.