### PR TITLE
Skip mysteriously empty fake track items

### DIFF
--- a/pyportify/app.py
+++ b/pyportify/app.py
@@ -156,9 +156,10 @@ def transfer_playlists(request, s, g, sp_playlist_uris):
 
         tasks = []
         for i, sp_track in enumerate(sp_playlist_tracks):
-            query = SpotifyQuery(i, sp_playlist_uri, sp_track, track_count)
-            future = search_gm_track(request, g, query)
-            tasks.append(future)
+            if sp_track['track'] is not None:
+                query = SpotifyQuery(i, sp_playlist_uri, sp_track, track_count)
+                future = search_gm_track(request, g, query)
+                tasks.append(future)
 
         done = yield from asyncio.gather(*tasks)
         gm_track_ids = [i for i in done if i is not None]


### PR DESCRIPTION
Fixes https://github.com/rckclmbr/pyportify/issues/64

Perhaps there's a more idiomatic way to do so, some sort of iterable filtering or something? But anyway, this fixes it. I had the issue on a few playlists.
