### PR TITLE
Update aiohttp version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==2.3.3
+aiohttp==2.3.10
 requests==2.18.4
 six==1.11.0
 certifi>=2017.11.5


### PR DESCRIPTION
Fixes #128 , as aiohttp updated to remove internal calls to deprecated
yarl logic.