### PR TITLE
Increase track match accuracy

### DIFF
--- a/pyportify/google.py
+++ b/pyportify/google.py
@@ -44,8 +44,8 @@ class Mobileclient(object):
                                                "ct": "1,2,3,4,6,7,8,9"})
         return data
 
-    async def find_best_track(self, search_query):
-        track = None
+    async def find_best_tracks(self, search_query):
+        tracks = []
         for i in range(0, 2):
             data = await self.search_all_access(search_query)
             if 'suggestedQuery' in data:
@@ -55,11 +55,10 @@ class Mobileclient(object):
                 continue
             for entry in data["entries"]:
                 if entry["type"] == "1":
-                    track = entry["track"]
-                    break
-            if track:
+                    tracks.append(entry["track"])
+            if tracks:
                 break
-        return track
+        return tracks
 
     async def fetch_playlists(self):
         data = await self._http_post("/playlistfeed", {})

--- a/pyportify/serializers.py
+++ b/pyportify/serializers.py
@@ -1,0 +1,27 @@
+class Track():
+    artist = ""
+    name = ""
+    track_id = ""
+
+    def __init__(self, artist, name, track_id=""):
+        self.artist = artist
+        self.name = name
+        self.track_id = track_id
+
+    @staticmethod
+    def from_spotify(self, track):
+        track_id = track.get("id")
+        name = track.get("name")
+        artist = ""
+        if "artists" in track:
+            artist = track["artists"][0]["name"]
+
+        return Track(artist, name, track_id)
+
+    @staticmethod
+    def from_gpm(self, track):
+        return Track(
+            track.get("artist"),
+            track.get("title"),
+            track.get("storeId")
+        )

--- a/pyportify/spotify.py
+++ b/pyportify/spotify.py
@@ -1,26 +1,27 @@
 import urllib
 
+from pyportify.serializers import Track
+
 
 class SpotifyQuery():
 
     def __init__(self, i, sp_playlist_uri, sp_track, track_count):
+        self.track = Track.from_spotify(sp_track.get("track", {}))
         self.i = i
         self.playlist_uri = sp_playlist_uri
-        self.sp_track = sp_track
         self.track_count = track_count
 
     def search_query(self):
-        track = self.sp_track.get("track")
-        if not track:
+        track = self.track
+        if not track.name or not track.artist:
             return None
 
-        if "artists" in track:
-            sp_artist = track['artists'][0]
+        if track.artist:
             search_query = "{0} - {1}".format(
-                sp_artist['name'],
-                track['name'])
+                track.artist,
+                track.name)
         else:
-            search_query = "{0}".format(self.sp_track['name'])
+            search_query = "{0}".format(track.name)
         return search_query
 
 

--- a/pyportify/tests.py
+++ b/pyportify/tests.py
@@ -1,5 +1,7 @@
 import unittest
 from pyportify import app
+from pyportify.serializers import Track
+from pyportify.util import find_closest_match
 
 
 class UserScopeTest(unittest.TestCase):
@@ -9,3 +11,120 @@ class UserScopeTest(unittest.TestCase):
 
         assert not scope.google_token
         assert not scope.spotify_token
+
+
+class TrackMatchTest(unittest.TestCase):
+
+    def test_artist_match(self):
+        target_artist = "Target"
+        target_name = "Songs to Test By"
+        expected_id = 1
+
+        target_track = Track(
+            artist=target_artist,
+            name=target_name
+        )
+        expected_match = Track(
+            artist=target_artist,
+            name=target_name,
+            track_id=expected_id
+        )
+        unexpected_match = Track(
+            artist="Not Me!",
+            name=target_name
+        )
+
+        match = find_closest_match(target_track, [
+            expected_match,
+            unexpected_match
+        ])
+
+        assert match.track_id == expected_id
+
+    def test_artist_match_close_track_name(self):
+        target_artist = "Target"
+        target_name = "Songs to Test By"
+        expected_id = 1
+
+        target_track = Track(
+            artist=target_artist,
+            name=target_name
+        )
+        expected_match = Track(
+            artist=target_artist,
+            name="Songs to Test With",
+            track_id=expected_id
+        )
+        unexpected_match = Track(
+            artist="Not Me, but my track name is closer!",
+            name=target_name
+        )
+
+        match = find_closest_match(target_track, [
+            expected_match,
+            unexpected_match
+        ])
+
+        assert match.track_id == expected_id
+
+    def test_close_artist_and_name_match(self):
+        target_artist = "Target"
+        target_name = "Songs to Test By"
+        expected_id = 1
+
+        target_track = Track(
+            artist=target_artist,
+            name=target_name
+        )
+        expected_match = Track(
+            artist="Targ",
+            name="Songs to Test With",
+            track_id=expected_id
+        )
+        unexpected_match = Track(
+            artist="Not Me!",
+            name=target_name
+        )
+
+        match = find_closest_match(target_track, [
+            expected_match,
+            unexpected_match
+        ])
+
+        assert match.track_id == expected_id
+
+    def test_multi_artist_match(self):
+        target_artist = "Target"
+        target_name = "Songs to Test By"
+        expected_id = 1
+
+        target_track = Track(
+            artist=target_artist,
+            name=target_name
+        )
+        expected_match = Track(
+            artist=target_artist,
+            name=target_name,
+            track_id=expected_id
+        )
+        un_exp_match1 = Track(
+            artist=target_artist,
+            name="Songs to Test With?"
+        )
+        un_exp_match2 = Track(
+            artist=target_artist,
+            name="Songs to Test With! - ft. Test"
+        )
+        un_exp_match3 = Track(
+            artist="Not Me!",
+            name=target_name
+        )
+
+        match = find_closest_match(target_track, [
+            expected_match,
+            un_exp_match1,
+            un_exp_match2,
+            un_exp_match3
+        ])
+
+        assert match.track_id == expected_id

--- a/pyportify/util.py
+++ b/pyportify/util.py
@@ -1,6 +1,8 @@
 import itertools
 import sys
 
+from difflib import SequenceMatcher as SM
+
 
 def uprint(*objects, sep=' ', end='\n', file=sys.stdout):
     enc = file.encoding
@@ -21,3 +23,32 @@ def grouper(iterable, n):
         if not chunk:
             return
         yield chunk
+
+
+def get_similarity(s1, s2):
+    """
+    Return similarity of both strings as a float between 0 and 1
+    """
+    return SM(None, s1, s2).ratio()
+
+
+def find_closest_match(target_track, tracks):
+    """
+    Return closest match to target track
+    """
+    track = None
+    # Get a list of (track, artist match ratio, name match ratio)
+    tracks_with_match_ratio = [(
+        track,
+        get_similarity(target_track.artist, track.artist),
+        get_similarity(target_track.name, track.name),
+    ) for track in tracks]
+    # Sort by artist then by title
+    sorted_tracks = sorted(
+        tracks_with_match_ratio,
+        key=lambda t: (t[1], t[2]),
+        reverse=True  # Descending, highest match ratio first
+    )
+    if sorted_tracks:
+        track = sorted_tracks[0][0]  # Closest match to query
+    return track


### PR DESCRIPTION
This Pull Request increases the accuracy of track matches, and addresses issue https://github.com/rckclmbr/pyportify/issues/76

I have added a new `Track` object in a `serializers.py` file in order to keep the matching code decoupled from GPM/Spotify, as well as not adding any additional coupling with my modifications of the google/spotify api files. Both these two files are still as generic as before, but the `search_gm_track` function in `app.py` now serializes the tracks it gets back from GPM and finds the best match by using a new util function.

The tracks are matched based on artist name first, then based on track name. This means that a track named "Best Song (Ft. Me)" by artist "Dave" will be matched to a song on GPM like "Best Song - Ft Me" by "Dave", instead of a different artist who has a track with a name that more closely matches the original.

I have also added tests to make sure the functionality works as expected.