### PR TITLE
fixing hanging app if you pick an empty playlist

### DIFF
--- a/pyportify/app.py
+++ b/pyportify/app.py
@@ -122,6 +122,13 @@ async def transfer_playlists(request, s, g, sp_playlist_uris):
             sp_playlist_uri)
 
         track_count = len(sp_playlist_tracks)
+        if track_count == 0:
+            uprint(
+                "Skipping empty playlist %s" %
+                (sp_playlist['name'])
+            )
+            continue
+
         uprint(
             "Gathering tracks for playlist %s (%s)" %
             (sp_playlist['name'], track_count)


### PR DESCRIPTION
If you happen to pick a playlist that has nothing in it, the app will wait forever because it doesn't check for `len() == 0`. Tested on Linux with Chrome 74. Unit tests report passing as well.